### PR TITLE
Add new investment subtypes and allow for none

### DIFF
--- a/app/models/investment.rb
+++ b/app/models/investment.rb
@@ -2,16 +2,19 @@ class Investment < ApplicationRecord
   include Accountable
 
   SUBTYPES = [
+    [ "None", nil ],
     [ "Brokerage", "brokerage" ],
     [ "Pension", "pension" ],
     [ "Retirement", "retirement" ],
     [ "401(k)", "401k" ],
-    [ "529 plan", "529_plan" ],
+    [ "Roth 401k", "roth_401k" ],
+    [ "529 Plan", "529_plan" ],
     [ "Health Savings Account", "hsa" ],
     [ "Mutual Fund", "mutual_fund" ],
+    [ "Traditional IRA", "traditional_ira" ],
     [ "Roth IRA", "roth_ira" ],
-    [ "Roth 401k", "roth_401k" ],
-    [ "Angel", "angel" ]
+    [ "Angel", "angel" ],
+    [ "Cryptocurrency", "cryptocurrency" ]
   ].freeze
 
   def value


### PR DESCRIPTION
- Add additional investment subtypes
- Allow for "None" option since any editing defaults to "Brokerage" right now.
- Small reorder to put the 401k options next to each other